### PR TITLE
Fix shift-enter from cell with figure

### DIFF
--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -143,12 +143,6 @@ mpl.figure.prototype._key_event_extra = function(event, name) {
     // Check for shift+enter
     if (event.shiftKey && event.which == 13) {
         this.canvas_div.blur();
-        event.shiftKey = false;
-        // Send a "J" for go to next cell
-        event.which = 74;
-        event.keyCode = 74;
-        manager.command_mode();
-        manager.handle_keydown(event);
     }
 }
 


### PR DESCRIPTION
Same as #matplotlib/matplotlib6752 which was merged into the non widgets notebook backend after the split.

As far as I can see in my tests the explicit shift of cell is no longer needed in the with the widgets based backend so this removes it. I still have to do shift-enter twice after a figure cell to get the next to execute but this is better than the current behaviour which just skips the next cell and consistent with the behaviour in the matplotlib 2.x non widgets backend 