### PR TITLE
Close widget when figure is closed from python

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -209,7 +209,7 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
             self.canvas.draw_idle()
 
     def destroy(self):
-        self._send_event('close')
+        self.canvas.close()
 
 
 def new_figure_manager(num, *args, **kwargs):


### PR DESCRIPTION
This ensures that the figure in the notebook is closed correctly when closed 

I.e. 
```
plt.plot(range(10))
```
creates a figure and then in a new cell. Assuming this is the first figure we can close it whit

```
plt.close(1)
```
In a new cell. Currently this does not have any visual effect. This change ensures that the figure is closed in the notebook.

I have removed the `self._send_event('close')` because it seems to trigger a no comms warning. As I understand it this no longer needed anyway as the widget handles the closing.