### PR TITLE
API: change focus policy + rm nb special case

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/matplotlib/jupyter-matplotlib.git"
   },
   "scripts": {
-    "prepublish": "webpack",
+      "prepublish": "webpack",
+      "build": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -125,7 +125,7 @@ mpl.figure.prototype._init_canvas = function() {
 
     var canvas_div = $('<div/>');
 
-    canvas_div.attr('style', 'position: relative; clear: both; outline: 0');
+    canvas_div.attr('style', 'position: relative; clear: both;');
 
     function canvas_keyboard_event(event) {
         event.stopPropagation();
@@ -141,7 +141,7 @@ mpl.figure.prototype._init_canvas = function() {
 
     var canvas = $('<canvas/>');
     canvas.addClass('mpl-canvas');
-    canvas.attr('style', "left: 0; top: 0; z-index: 0; outline: 0")
+    canvas.attr('style', "left: 0; top: 0; z-index: 0; ")
 
     this.canvas = canvas[0];
     this.context = canvas[0].getContext("2d");

--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -128,6 +128,8 @@ mpl.figure.prototype._init_canvas = function() {
     canvas_div.attr('style', 'position: relative; clear: both; outline: 0');
 
     function canvas_keyboard_event(event) {
+        event.stopPropagation();
+        event.preventDefault();
         return fig.key_event(event, event['data']);
     }
 
@@ -225,13 +227,6 @@ mpl.figure.prototype._init_canvas = function() {
     $(this.rubberband_canvas).bind("contextmenu",function(e){
         return false;
     });
-
-    function set_focus () {
-        canvas.focus();
-        canvas_div.focus();
-    }
-
-    window.setTimeout(set_focus, 100);
 }
 
 mpl.figure.prototype._init_toolbar = function() {

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -58,9 +58,6 @@ mpl.figure.prototype.handle_close = function(fig, msg) {
     var width = fig.canvas.width/mpl.ratio
     fig.root.unbind('remove')
 
-    // Re-enable the keyboard manager in Jupyter - without this line, in FF,
-    // the notebook keyboard shortcuts fail.
-    Jupyter.keyboard_manager.enable()
     fig.close_ws(fig, msg);
 }
 
@@ -127,23 +124,11 @@ mpl.figure.prototype._root_extra_style = function(el){
 }
 
 mpl.figure.prototype._canvas_extra_style = function(el){
-    // this is important to make the div 'focusable
+    // this is important to make the div 'focusable'
     el.attr('tabindex', 0)
-    // reach out to Jupyter and tell the keyboard manager to turn it's self
-    // off when our div gets focus
-
-    Jupyter.notebook.keyboard_manager.register_events(el);
 }
 
 mpl.figure.prototype._key_event_extra = function(event, name) {
-    var manager = Jupyter.notebook.keyboard_manager;
-    if (!manager)
-        manager = Jupyter.keyboard_manager;
-
-    // Check for shift+enter
-    if (event.shiftKey && event.which == 13) {
-        this.canvas_div.blur();
-    }
 }
 
 mpl.figure.prototype.handle_save = function(fig, msg) {


### PR DESCRIPTION
Do not focus on creation, user must actively click on the figure
to get focus (and hence have the figure keyboard events).

This allows us to remove the shift-enter special case (which will be
configurable in jh).

Disable propagation on any keyboard events that the figure gets, which
removes the need for the keyboard_manager special casing.