### PR TITLE
Update for ipywidgets 7.0 and JupyterLab 0.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Matplotlib Jupyter Extension.
 This repository contains code for the Matplotlib Jupyter widget, stripped out
 of the main matplotlib repository.
 
-It requires matplotlib 2.0.0 or more recent.
+It requires matplotlib 2.0 or and ipywidgets 7.0 more recent.
 
 The goal of this project is to separate developement of the Jupyter integration
 (future versions of notebook and Jupyter Lab) from the calendar of the releases
@@ -22,12 +22,14 @@ Installation
 To install `ipympl` with conda:
 
     $ conda install ipympl -c conda-forge
+    $ jupyter labextension install matplotlib-jupyter
 
 
 To install `ipympl` with pip:
 
     $ pip install ipympl
     $ jupyter nbextension enable --py --sys-prefix ipympl
+    $ jupyter labextension install matplotlib-jupyter
 
 
 For a development installation (requires npm),
@@ -37,3 +39,4 @@ For a development installation (requires npm),
     $ pip install -e .
     $ jupyter nbextension install --py --symlink --sys-prefix ipympl
     $ jupyter nbextension enable --py --sys-prefix ipympl
+    $ cd js && npm run watch

--- a/README.md
+++ b/README.md
@@ -39,4 +39,6 @@ For a development installation (requires npm),
     $ pip install -e .
     $ jupyter nbextension install --py --symlink --sys-prefix ipympl
     $ jupyter nbextension enable --py --sys-prefix ipympl
-    $ cd js && npm run watch
+    $ jupyter labextension link ./js
+    $ cd js && npm run watch  
+    $ # Launch jupyterlab as `jupyter lab --watch` in another terminal

--- a/ipympl/__init__.py
+++ b/ipympl/__init__.py
@@ -1,6 +1,9 @@
+import sys
+import matplotlib
 from ._version import version_info, __version__
 
 npm_pkg_name = 'jupyter-matplotlib'
+
 
 def _jupyter_nbextension_paths():
     return [{
@@ -10,6 +13,11 @@ def _jupyter_nbextension_paths():
         'require': npm_pkg_name + '/extension'
     }]
 
-import matplotlib
+
+# Ensure that `widget` is not selected as the backend name by IPython,
+# which causes a UsageError.
+if 'IPython' in sys.modules:
+    from IPython.core.pylabtools import backend2gui
+    backend2gui['module://ipympl.backend_nbagg'] = 'ipympl'
 
 matplotlib.use('module://ipympl.backend_nbagg')

--- a/ipympl/__init__.py
+++ b/ipympl/__init__.py
@@ -10,12 +10,6 @@ def _jupyter_nbextension_paths():
         'require': npm_pkg_name + '/extension'
     }]
 
-def _jupyter_labextension_paths():
-    return [{
-        'name': npm_pkg_name,
-        'src': 'staticlab'
-    }]
-
 import matplotlib
 
 matplotlib.use('module://ipympl.backend_nbagg')

--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -103,8 +103,7 @@ class NavigationIPy(NavigationToolbar2WebAgg):
                   _FONT_AWESOME_CLASSES[image_file], name_of_method)
                  for text, tooltip_text, image_file, name_of_method
                  in (NavigationToolbar2.toolitems +
-                     (('Download', 'Download plot', 'download', 'download'),
-                      ('Export', 'Export plot', 'export', 'export')))
+                     (('Download', 'Download plot', 'download', 'download'),))
                  if image_file in _FONT_AWESOME_CLASSES]
 
     def export(self):

--- a/js/package.json
+++ b/js/package.json
@@ -11,18 +11,23 @@
   },
   "scripts": {
     "build": "webpack",
-    "prepublish": "npm run build",
+    "clean": "rimraf dist/",
+    "postinstall": "npm run clean && npm run build",
+    "prepack": "npm run postinstall",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "jupyterlab": {
+    "extension": "src/labplugin"
   },
   "devDependencies": {
     "json-loader": "^0.5.4",
-    "@jupyterlab/extension-builder": "^0.10.0",
-    "webpack": "^1.12.14"
+    "webpack": "^3.5.5",
+    "rimraf": "^2.6.1"
   },
   "dependencies": {
     "jquery": "^2.1.4",
-    "jupyter-js-widgets": "^2.1.4",
-    "@jupyterlab/nbwidgets": "^0.6.15",
-    "underscore": "^1.8.3"
+    "@jupyter-widgets/base": "^1.0.0",
+    "@jupyter-widgets/jupyterlab-manager": "^0.28.0",
+    "lodash": "^4.17.4"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,8 @@
     "clean": "rimraf dist/",
     "postinstall": "npm run clean && npm run build",
     "prepack": "npm run postinstall",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "webpack --watch"
   },
   "jupyterlab": {
     "extension": "src/labplugin"

--- a/js/src/extension.js
+++ b/js/src/extension.js
@@ -3,7 +3,6 @@ if (window.require) {
         map: {
             "*" : {
                 "jupyter-matplotlib": "nbextensions/jupyter-matplotlib/index",
-                "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
             }
         }
     });

--- a/js/src/labplugin.js
+++ b/js/src/labplugin.js
@@ -1,9 +1,9 @@
 var jupyter_matplotlib = require('./index');
 
-var jupyterlab_widgets = require('@jupyterlab/nbwidgets');
+var jupyterlab_widgets = require('@jupyter-widgets/jupyterlab-manager');
 
 module.exports = {
-    id: 'jupyter.extensions.jupyter-matplotlib',
+    id: 'matplotlib-jupyter:main',
     requires: [jupyterlab_widgets.INBWidgetExtension],
     activate: function(app, widgets) {
         widgets.registerWidget({

--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -282,7 +282,7 @@ mpl.figure.prototype._init_toolbar = function() {
     nav_element.append(fmt_picker_span);
     this.format_dropdown = fmt_picker[0];
 
-    for (var ind in ["png", "jpg"]) {
+    for (var ind in mpl.extensions) {
         var fmt = mpl.extensions[ind];
         var option = $(
             '<option/>', {selected: fmt === mpl.default_extension}).html(fmt);

--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -282,7 +282,7 @@ mpl.figure.prototype._init_toolbar = function() {
     nav_element.append(fmt_picker_span);
     this.format_dropdown = fmt_picker[0];
 
-    for (var ind in mpl.extensions) {
+    for (var ind in ["png", "jpg"]) {
         var fmt = mpl.extensions[ind];
         var option = $(
             '<option/>', {selected: fmt === mpl.default_extension}).html(fmt);

--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -45,6 +45,7 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
     }
 
     this.imageObj = new Image();
+    this.imageObj.className = 'mpl-imageObj';
 
     this.context = undefined;
     this.message = undefined;
@@ -122,7 +123,7 @@ mpl.figure.prototype._init_canvas = function() {
 
     var canvas_div = $('<div/>');
 
-    canvas_div.attr('style', 'position: relative; clear: both;');
+    canvas_div.attr('style', 'position: relative; clear: both; outline:none');
 
     function canvas_keyboard_event(event) {
         event.stopPropagation();

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -88,13 +88,13 @@ mpl.figure.prototype.toggle_interaction = function(fig, msg) {
     if (visible) {
         fig.toolbar.hide();
         fig.canvas_div.hide();
-        fig.root.append(fig.imageObj);
+        fig.imageObj_div.show();
         fig.imageObj.style.width = fig.canvas.style.width;
         fig.imageObj.style.height = fig.canvas.style.height;
     } else {
         fig.toolbar.show();
         fig.canvas_div.show();
-        fig.root.remove('.mpl-imageObj');
+        fig.imageObj_div.hide();
     }
 }
 

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -20,20 +20,6 @@ var MPLCanvasModel = widgets.DOMWidgetModel.extend({
 });
 
 
-function open_data_uri_window(url) {
-   // Open a new window with a data uri
-   // https://stackoverflow.com/a/45585922
-   var html = '<html>' +
-    '<style>html, body { padding: 0; margin: 0; } iframe { width: 100%; height: 100%; border: 0;}  </style>' +
-    '<body>' +
-    '<iframe type="image/png" src="' + url + '"></iframe>' +
-    '</body></html>';
-    var a = window.open("about:blank", "Matplotib Widget");
-    a.document.write(html);
-    a.document.close();
-}
-
-
 var MPLCanvasView = widgets.DOMWidgetView.extend({
 
     render: function() {
@@ -44,7 +30,12 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
         this.ws_proxy = this.comm_websocket_adapter(this.model.comm);
 
         function ondownload(figure, format) {
-            open_data_uri_window(figure.imageObj.src);
+           var save = document.createElement('a');
+           save.href = figure.imageObj.src;
+           save.download = figure.header.textContent + '.png';
+           document.body.appendChild(save);
+           save.click();
+           document.body.removeChild(save);
         }
 
         mpl.toolbar_items = this.model.get('_toolbar_items')

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,24 +1,12 @@
+var path = require('path');
 var version = require('./package.json').version;
 
-// Custom webpack loaders are generally the same for all webpack bundles, hence
+// Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
-var loaders = [
-    { test: /\.json$/, loader: 'json-loader' },
-];
+var rules = [
+    { test: /\.css$/, use: ['style-loader', 'css-loader']}
+]
 
-var buildExtension = require('@jupyterlab/extension-builder/lib/builder').buildExtension;
-
-buildExtension({
-    name: 'jupyter-matplotlib',
-    entry: './src/labplugin',
-    outputDir: '../ipympl/staticlab',
-    useDefaultLoaders: false,
-    config: {
-        module: {
-            loaders: loaders
-        }
-    }
-});
 
 module.exports = [
     {// Notebook extension
@@ -32,7 +20,7 @@ module.exports = [
         entry: './src/extension.js',
         output: {
             filename: 'extension.js',
-            path: '../ipympl/static',
+            path: path.resolve(__dirname, '..', 'ipympl', 'static'),
             libraryTarget: 'amd'
         }
     },
@@ -44,14 +32,14 @@ module.exports = [
         entry: './src/index.js',
         output: {
             filename: 'index.js',
-            path: '../ipympl/static',
+            path: path.resolve(__dirname, '..', 'ipympl', 'static'),
             libraryTarget: 'amd'
         },
         devtool: 'source-map',
         module: {
-            loaders: loaders
+            rules: rules
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['@jupyter-widgets/base']
     },
     {// Embeddable jupyter-matplotlib bundle
      //
@@ -70,14 +58,14 @@ module.exports = [
         entry: './src/embed.js',
         output: {
             filename: 'index.js',
-            path: './dist/',
+            path: path.resolve(__dirname, 'dist'),
             libraryTarget: 'amd',
             publicPath: 'https://unpkg.com/jupyter-matplotlib@' + version + '/dist/'
         },
         devtool: 'source-map',
         module: {
-            loaders: loaders
+            rules: rules
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['@jupyter-widgets/base']
     }
 ];

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup_args = {
     ],
     'install_requires': [
         'ipywidgets>=7.0.0',
-        'matplotlib>=2.1.0',
+        'matplotlib>=2.0.0',
         'six',
     ],
     'packages': find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -127,15 +127,11 @@ setup_args = {
             'ipympl/static/extension.js',
             'ipympl/static/index.js',
             'ipympl/static/index.js.map',
-        ]),
-        ('share/jupyter/labextensions/jupyter-matplotlib', [
-            'ipympl/staticlab/jupyter-matplotlib.bundle.js',
-            'ipympl/staticlab/jupyter-matplotlib.bundle.js.manifest',
         ])
     ],
     'install_requires': [
-        'ipywidgets>=6.0.0',
-        'matplotlib>=2.0.0',
+        'ipywidgets>=7.0.0',
+        'matplotlib>=2.1.0',
         'six',
     ],
     'packages': find_packages(),


### PR DESCRIPTION
Fixes #15. 

- Removed export button and fixed the handling of interactivity toggling.
- Fixed the download image behavior since Chrome no longer supports data urls for `window.open`.

![mpl-widget](https://user-images.githubusercontent.com/2096628/32134903-113e0176-bbbc-11e7-8291-bcf8d95cde61.gif)
