### PR TITLE
Support the matplotlib widget backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of the main matplotlib repository.
 
 It requires matplotlib 2.0 or and ipywidgets 7.0 more recent.
 
-The goal of this project is to separate developement of the Jupyter integration
+The goal of this project is to separate development of the Jupyter integration
 (future versions of notebook and Jupyter Lab) from the calendar of the releases
 of the main matplotlib repository.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ The goal of this project is to separate developement of the Jupyter integration
 (future versions of notebook and Jupyter Lab) from the calendar of the releases
 of the main matplotlib repository.
 
+Example:
+
+```python
+%matplotlib widget
+import matplotlib.pyplot as plt
+
+plt.plot([0, 1, 2, 2])
+plt.show()
+```
+
+
 Installation
 ------------
 

--- a/examples/ipympl.ipynb
+++ b/examples/ipympl.ipynb
@@ -10,7 +10,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "451e8fcc5b66406ba64a638e324f46e0",
+       "model_id": "d458bcd97d6e455481b724bf1b362770",
        "version_major": 2,
        "version_minor": 0
       },
@@ -48,9 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/examples/ipympl.ipynb
+++ b/examples/ipympl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -10,7 +10,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "610bf0a477bd4e95bcef5a64ee6d0202",
+       "model_id": "451e8fcc5b66406ba64a638e324f46e0",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/ipympl.ipynb
+++ b/examples/ipympl.ipynb
@@ -2,13 +2,43 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "610bf0a477bd4e95bcef5a64ee6d0202",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>FigureCanvasNbAgg</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another notebook frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "FigureCanvasNbAgg()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "import ipympl\n",
+    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "plt.plot([0, 1, 2, 2])\n",
@@ -27,7 +57,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -41,9 +71,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/ipympl/__init__.py
+++ b/ipympl/__init__.py
@@ -14,10 +14,4 @@ def _jupyter_nbextension_paths():
     }]
 
 
-# Ensure that `widget` is not selected as the backend name by IPython,
-# which causes a UsageError.
-if 'IPython' in sys.modules:
-    from IPython.core.pylabtools import backend2gui
-    backend2gui['module://ipympl.backend_nbagg'] = 'ipympl'
-
 matplotlib.use('module://ipympl.backend_nbagg')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools.command.egg_info import egg_info
 from subprocess import check_call
 import glob
 import os
-import shutil
 import sys
 from os.path import join as pjoin
 
@@ -17,7 +16,7 @@ tar_path = pjoin(here, 'ipympl', '*.tgz')
 
 npm_path = os.pathsep.join([
     pjoin(node_root, 'node_modules', '.bin'),
-                os.environ.get('PATH', os.defpath),
+            os.environ.get('PATH', os.defpath),
 ])
 
 from distutils import log
@@ -154,6 +153,7 @@ setup_args = {
     'include_package_data': True,
     'data_files': get_data_files(),
     'install_requires': [
+        'ipykernel>=4.7',
         'ipywidgets>=7.0.0',
         'matplotlib>=2.0.0',
         'six',


### PR DESCRIPTION
Thanks to the `ipykernel@4.7` [release](https://github.com/ipython/ipykernel/pull/275), we can now use:

```python
%matplotlib widget
import matplotlib.pyplot as plt

plt.plot([0, 1, 2, 2])
plt.show()
```