### PR TITLE
removing warnings from nbagg backend

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -237,7 +237,7 @@ def new_figure_manager_given_figure(num, figure):
         Gcf.destroy(num)
 
     canvas = FigureCanvasNbAgg(figure)
-    if rcParams['nbagg.transparent']:
+    if 'nbagg.transparent' in set(rcParams.keys()) and rcParams['nbagg.transparent']:
         figure.patch.set_alpha(0)
     manager = FigureManagerNbAgg(canvas, num)
 


### PR DESCRIPTION
Removes nbagg.transparent deprecation warnings when nbagg.transparent isn't in the user's rcParams. Fixes issue #41.