### PR TITLE
Use ipywidgets CSS for controls

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -79,16 +79,14 @@ def connection_info():
 # Note: Version 3.2 and 4.x icons
 # http://fontawesome.io/3.2.1/icons/
 # http://fontawesome.io/
-# the `fa fa-xxx` part targets font-awesome 4, (IPython 3.x)
-# the icon-xxx targets font awesome 3.21 (IPython 2.x)
 _FONT_AWESOME_CLASSES = {
-    'home': 'fa fa-home icon-home',
-    'back': 'fa fa-arrow-left icon-arrow-left',
-    'forward': 'fa fa-arrow-right icon-arrow-right',
-    'zoom_to_rect': 'fa fa-square-o icon-check-empty',
-    'move': 'fa fa-arrows icon-move',
-    'download': 'fa fa-floppy-o icon-save',
-    'export': 'fa fa-file-picture-o icon-picture',
+    'home': 'fa fa-home',
+    'back': 'fa fa-arrow-left',
+    'forward': 'fa fa-arrow-right',
+    'zoom_to_rect': 'fa fa-square-o',
+    'move': 'fa fa-arrows',
+    'download': 'fa fa-floppy-o',
+    'export': 'fa fa-file-picture-o',
     None: None
 }
 

--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -84,14 +84,8 @@ mpl.figure = function(figure_id, websocket, ondownload, parent_element) {
 }
 
 mpl.figure.prototype._init_header = function() {
-    var titlebar = $(
-        '<div class="ui-dialog-titlebar ui-widget-header ui-corner-all ' +
-        'ui-helper-clearfix"/>');
-    var titletext = $(
-        '<div class="ui-dialog-title" style="width: 100%; ' +
-        'text-align: center; padding: 3px;"/>');
-    titlebar.append(titletext)
-    this.root.append(titlebar);
+    var titletext = $('<div style="width: 100%; text-align: center; padding: 3px;"/>');
+    this.root.append(titletext);
     this.header = titletext[0];
 }
 

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -106,9 +106,18 @@ mpl.figure.prototype.updated_canvas_event = function() {
 mpl.figure.prototype._init_toolbar = function() {
     var fig = this;
 
-    var toolbar = this.toolbar = $('<div/>')
-    toolbar.attr('style', 'width: 100%');
-    this.root.append(toolbar);
+    var toolbar_container = this.toolbar = $('<div class="jupyter-widgets widget-container widget-box widget-hbox"/>')
+    this.root.prepend(toolbar_container);
+
+    // Add the stop interaction button to the window.
+    var button = $('<button class="jupyter-widgets jupyter-button" href="#" title="Toggle Interaction"><i class="fa fa-bars"></i></button>');
+    button.attr('style', 'outline:none');
+    button.click(function (evt) { fig.toggle_interaction(fig, {}); } );
+    button.mouseover('Toggle Interaction', toolbar_mouse_event);
+    toolbar_container.append(button);
+
+    var toolbar = this.toolbar = $('<div class="jupyter-widgets widget-container widget-box widget-hbox"/>')
+    toolbar_container.append(toolbar);
 
     // Define a callback function for later on.
     function toolbar_event(event) {
@@ -125,7 +134,7 @@ mpl.figure.prototype._init_toolbar = function() {
         var method_name = mpl.toolbar_items[toolbar_ind][3];
         if (!name) { continue; };
 
-        var button = $('<button class="btn btn-default" href="#" title="' + name + '"><i class="fa ' + image + ' fa-lg"></i></button>');
+        var button = $('<button class="jupyter-widgets jupyter-button" href="#" title="' + name + '"><i class="fa ' + image + '"></i></button>');
         button.attr('style', 'outline:none');
         button.click(method_name, toolbar_event);
         button.mouseover(tooltip, toolbar_mouse_event);
@@ -136,16 +145,6 @@ mpl.figure.prototype._init_toolbar = function() {
     var status_bar = $('<span class="mpl-message" style="text-align:right; float: right;"/>');
     toolbar.append(status_bar);
     this.message = status_bar[0];
-
-    // Add the stop interaction button to the window.
-    var buttongrp = $('<div class="btn-group inline pull-right"></div>');
-    var button = $('<button class="btn btn-mini btn-primary" href="#" title="Toggle Interaction"><i class="fa fa-power-off icon-remove icon-large"></i></button>');
-    button.attr('style', 'outline:none');
-    button.click(function (evt) { fig.toggle_interaction(fig, {}); } );
-    button.mouseover('Toggle Interaction', toolbar_mouse_event);
-    buttongrp.append(button);
-    var titlebar = this.root.find('.ui-dialog-titlebar');
-    titlebar.prepend(buttongrp);
 }
 
 mpl.figure.prototype._root_extra_style = function(el) {


### PR DESCRIPTION
Use ipywidgets CSS for controls, for a modernized style.

![test_ipympl](https://user-images.githubusercontent.com/21197331/59782651-b8009c00-92be-11e9-8dfa-5c1c839786cd.gif)
