### PR TITLE
Fix visual glitch when hiding the toolbar

### DIFF
--- a/js/src/mpl.js
+++ b/js/src/mpl.js
@@ -279,17 +279,9 @@ mpl.figure.prototype.toggle_interaction = function(fig, msg) {
     // Toggle the interactivity of the figure.
     var visible = fig.toolbar.style.display !== 'none';
     if (visible) {
-        console.log('hiding')
         fig.toolbar.style.display = 'none';
-        fig.canvas_div.style.display = 'none';
-        fig.image.style.display = '';
-        fig.image.style.width = fig.canvas.style.width;
-        fig.image.style.height = fig.canvas.style.height;
     } else {
-        console.log('display')
         fig.toolbar.style.display = '';
-        fig.canvas_div.style.display = '';
-        fig.image.style.display = 'none';
     }
 }
 


### PR DESCRIPTION
Fixed a visual glitch when toggling the toolbar, sometimes the plot was disappearing, sometimes it was weirdly displayed (I suppose we display the image diff, not the plot)

Before:
![glitch_before](https://user-images.githubusercontent.com/21197331/59908967-ed1c0400-940e-11e9-941d-fa21f666c8be.gif)

After:
![glitch_fixed](https://user-images.githubusercontent.com/21197331/59908976-f1e0b800-940e-11e9-8c56-74672cc336f6.gif)
