### PR TITLE
Hide header

### DIFF
--- a/examples/header_visible.ipynb
+++ b/examples/header_visible.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-08-07T08:07:06.908562Z",
+     "start_time": "2019-08-07T08:07:06.602919Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "fig.canvas.layout.width = '7in'\n",
+    "fig.canvas.layout.height= '5in'\n",
+    "\n",
+    "# if I hide the header here, I get a libpng error\n",
+    "# fig.canvas.header_visible = False\n",
+    "\n",
+    "ax.plot([1,2,3], [4,5,3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hiding after rendering works\n",
+    "fig.canvas.header_visible = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hiding together with calls to toolbar options, work.\n",
+    "fig, ax = plt.subplots()\n",
+    "fig.canvas.layout.width = '7in'\n",
+    "fig.canvas.layout.height= '5in'\n",
+    "\n",
+    "fig.canvas.toolbar_visible = False\n",
+    "fig.canvas.header_visible = False\n",
+    "\n",
+    "ax.plot([1,2,3], [4,5,3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -149,6 +149,9 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
     toolbar = Instance(Toolbar, allow_none=True).tag(sync=True, **widget_serialization)
     toolbar_visible = Bool(True).tag(sync=True)
     toolbar_position = Enum(['top', 'bottom', 'left', 'right'], default_value='left').tag(sync=True)
+
+    header_visible = Bool(True).tag(sync=True)
+
     _closed = Bool(True)
 
     # Must declare the superclass private members.

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -16,6 +16,7 @@ var MPLCanvasModel = widgets.DOMWidgetModel.extend({
             _view_module: 'jupyter-matplotlib',
             _model_module_version: '^'+ version,
             _view_module_version: '^' + version,
+            header_visible: true,
             toolbar: null,
             toolbar_visible: true,
             toolbar_position: 'horizontal'
@@ -64,6 +65,7 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
 
     model_events: function() {
         this.model.on('msg:custom', this.on_comm_message.bind(this));
+        this.model.on('change:header_visible', this.update_header_visible.bind(this));
         this.model.on('change:toolbar_visible', this.update_toolbar_visible.bind(this));
         this.model.on('change:toolbar_position', this.update_toolbar_position.bind(this));
     },
@@ -76,6 +78,11 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
         this.send_message('refresh');
 
         this.send_message('initialized');
+    },
+
+    update_header_visible: function() {
+        this.header.style.display = this.model.get('header_visible') ? '': 'none';
+        this.request_resize();
     },
 
     update_toolbar_visible: function() {


### PR DESCRIPTION
This branch contains a fix for hiding the figure header in the matplotlib widget, as discussed in issue #134 . I also added an example notebook to show how it works.
I have some issues with libpng errors, but I am not sure how they correspond to my code, as I see those in other cases as well. I will explain in the issue comments.