### PR TITLE
Prevent the context menu from opening on right click.

### DIFF
--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -182,6 +182,8 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
 
         // Disable right mouse context menu.
         this.rubberband_canvas.addEventListener('contextmenu', function(e) {
+            event.preventDefault();
+            event.stopPropagation();
             return false;
         });
     },


### PR DESCRIPTION
This fixes #143 by capturing right click presses so that they don't open the Jupyter Lab context menu.