### PR TITLE
Change to "notebook"-like behavior

### DIFF
--- a/js/src/mpl_widget.css
+++ b/js/src/mpl_widget.css
@@ -6,8 +6,13 @@
 
 /* Toolbar */
 
+.jupyter-matplotlib-toolbar {
+  flex: 0 0 auto;
+}
+
 .jupyter-matplotlib-button {
   width: calc(var(--jp-widgets-inline-width-tiny) / 2 - 2px);
+  overflow: hidden;
   padding: 0;
 }
 
@@ -16,6 +21,7 @@
 .jupyter-matplotlib-figure {
   width: auto;
   height: auto;
+  overflow: hidden;
 }
 
 .jupyter-matplotlib-canvas_div {

--- a/js/src/mpl_widget.css
+++ b/js/src/mpl_widget.css
@@ -1,6 +1,7 @@
 .jupyter-matplotlib {
-  height: 500px;
   flex: 1 1 auto;
+  width: auto;
+  height: auto;
 }
 
 /* Toolbar */
@@ -13,8 +14,8 @@
 /* Figure */
 
 .jupyter-matplotlib-figure {
-  width: 100%;
-  height: 100%;
+  width: auto;
+  height: auto;
 }
 
 .jupyter-matplotlib-canvas_div {

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -254,6 +254,13 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
     },
 
     request_resize: function() {
+        // Ensure that the image already exists. We ignore the first calls to resize
+        // because we want the widget to first adapt to the figure size set in
+        // matplotlib.
+        if (!this.image.src) {
+            return;
+        }
+
         // Using the given widget size, figure out how big the canvas should be.
         var decorations_size = this._calculate_decorations_size();
 
@@ -422,12 +429,7 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
 
         switch (msg.type) {
         case 'resize':
-            // Ensure that the image already exists. We ignore the very first call to
-            // resize because we want the widget to adapt to the figure size set in
-            // matplotlib.
-            if (this.image.src) {
-                this.request_resize();
-            }
+            this.request_resize();
             break;
         }
     },

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -231,6 +231,9 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
 
         this.rubberband_canvas.setAttribute('width', width);
         this.rubberband_canvas.setAttribute('height', height);
+
+        this.canvas_div.style.width = width + 'px';
+        this.canvas_div.style.height = height + 'px';
     },
 
     send_message: function(type, message = {}) {
@@ -360,17 +363,6 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
             } catch (e) {
                 console.log('Exception inside the \'handler_' + msg_type + '\' callback:', e, e.stack, msg);
             }
-        }
-    },
-
-    processPhosphorMessage: function(msg) {
-        MPLCanvasView.__super__.processPhosphorMessage.apply(this, arguments);
-
-        switch (msg.type) {
-        case 'resize':
-        // case 'after-show':
-            this.request_resize();
-            break;
         }
     },
 

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -41,8 +41,41 @@ function get_simple_keys(original) {
     }, {});
 }
 
+/*
+ * Return the total size of the margins for an element in both width and height.
+ */
+function get_margin_size(el) {
+    var style = getComputedStyle(el);
+
+    var margin_width = parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+    var margin_height = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+
+    return {
+        width: margin_width,
+        height: margin_height,
+    };
+}
+
+
+/*
+ * Return the full size of an element, including margins.
+ */
+function get_full_size(el) {
+    var margin_size = get_margin_size(el);
+
+    var full_width = el.scrollWidth + margin_size.width;
+    var full_height = el.scrollHeight + margin_size.height;
+
+    return {
+        width: full_width,
+        height: full_height,
+    };
+}
+
 module.exports = {
   offset: offset,
   get_mouse_position: get_mouse_position,
-  get_simple_keys: get_simple_keys
+  get_simple_keys: get_simple_keys,
+  get_margin_size: get_margin_size,
+  get_full_size: get_full_size,
 }


### PR DESCRIPTION
This is a first pass at addressing #117. With this implementation, the matplotlib backend controls the figure size, and the canvas size is automatically adjusted in Jupyter Lab to fit the figure.

With this commit, you can specify the figsize in plt.figure(), and fig.set_size_inches() can be used to update the size of the figure.

Note that high DPI images are not properly displayed in this first commit. This also breaks setting the height and width via "fig.canvas.layout.height".