### PR TITLE
Fix binder badge, add travis/conda/npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # jupyter-matplotlib
 
-[![Version](https://img.shields.io/pypi/v/ipympl.svg)](https://pypi.python.org/pypi/ipympl)
-[![Binder](https://img.shields.io/badge/launch-binder-brightgreen.svg)](https://mybinder.org/v2/gh/matplotlib/jupyter-matplotlib/stable?filepath=examples)
-[![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter-widgets/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![TravisCI build status](https://img.shields.io/travis/com/matplotlib/jupyter-matplotlib/master?logo=travis)](https://travis-ci.com/matplotlib/jupyter-matplotlib)
+[![Latest PyPI version](https://img.shields.io/pypi/v/ipympl?logo=pypi)](https://pypi.python.org/pypi/ipympl)
+[![Latest conda-forge version](https://img.shields.io/conda/vn/conda-forge/ipympl?logo=conda-forge)](https://www.npmjs.com/package/ipympl)
+[![Latest npm version](https://img.shields.io/npm/v/jupyter-matplotlib?logo=npm)](https://www.npmjs.com/package/jupyter-matplotlib)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matplotlib/jupyter-matplotlib/master?urlpath=%2Flab%2Ftree%2Fexamples%2Fipympl.ipynb)
+[![Gitter](https://img.shields.io/badge/gitter-Join_chat-blue?logo=gitter)](https://gitter.im/jupyter-widgets/Lobby)
 
 Leveraging the Jupyter interactive widgets framework, jupyter-matplotlib
 enables the interactive features of matplotlib in the Jupyter notebook and in

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - numpy
   - matplotlib-base>=2.2.2
   - ipympl=0.4.0
+  - widgetsnbextension

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# A way for mybinder.org to realize it should install the jupyter lab extension
+# automatically. This file does not affect anything except when mybinder.org use
+# it for this specifically.
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyter-matplotlib
+


### PR DESCRIPTION
Addresses #164, but the stable branch is still outdated so if anyone builds from that it is not up to date with 0.4.0 for example.