### PR TITLE
Update version to 0.4.1 for new package

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 - To release a new version of ipympl on PyPI:
 
+# nuke the  `dist` and `node_modules`
+git clean -fdx
+
 Update _version.py (set release version, remove 'dev')
 git add and git commit
 python setup.py sdist upload
@@ -11,8 +14,5 @@ git push
 git push --tags
 
 - To release a new version of jupyter-matplotlib on NPM:
-
-# nuke the  `dist` and `node_modules`
-git clean -fdx
 npm install
 npm publish

--- a/ipympl/_version.py
+++ b/ipympl/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 4, 0)
+version_info = (0, 4, 1)
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Move cleaning the repository step to before the wheel is
generated.

To re-package without old versions of jupyter-matplotlib-X.X.X.tgz.

To address: https://github.com/matplotlib/jupyter-matplotlib/issues/163