### PR TITLE
docs: fix conda-forge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![TravisCI build status](https://img.shields.io/travis/com/matplotlib/jupyter-matplotlib/master?logo=travis)](https://travis-ci.com/matplotlib/jupyter-matplotlib)
 [![Latest PyPI version](https://img.shields.io/pypi/v/ipympl?logo=pypi)](https://pypi.python.org/pypi/ipympl)
-[![Latest conda-forge version](https://img.shields.io/conda/vn/conda-forge/ipympl?logo=conda-forge)](https://www.npmjs.com/package/ipympl)
+[![Latest conda-forge version](https://img.shields.io/conda/vn/conda-forge/ipympl?logo=conda-forge)](https://anaconda.org/conda-forge/ipympl)
 [![Latest npm version](https://img.shields.io/npm/v/jupyter-matplotlib?logo=npm)](https://www.npmjs.com/package/jupyter-matplotlib)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matplotlib/jupyter-matplotlib/master?urlpath=%2Flab%2Ftree%2Fexamples%2Fipympl.ipynb)
 [![Gitter](https://img.shields.io/badge/gitter-Join_chat-blue?logo=gitter)](https://gitter.im/jupyter-widgets/Lobby)


### PR DESCRIPTION
Noticed the conda-forge url directed to npm.  This changes it to point to the conda-forge ipympl package on anaconda.org.