### PR TITLE
Remove all resizing logic on the front-end

### DIFF
--- a/examples/ipympl.ipynb
+++ b/examples/ipympl.ipynb
@@ -26,9 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Testing matplotlib interactions with a simple plot\n",
@@ -36,9 +34,18 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "plt.figure(1)\n",
-    "plt.plot(np.sin(np.linspace(0, 20, 100)))\n",
-    "plt.show()"
+    "fig = plt.figure()\n",
+    "plt.plot(np.sin(np.linspace(0, 20, 100)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.canvas.toolbar_visible = False\n",
+    "fig.canvas.header_visible = False"
    ]
   },
   {
@@ -144,7 +151,7 @@
     "    max=2.0\n",
     ")\n",
     "\n",
-    "fig = plt.figure(3)\n",
+    "fig = plt.figure()\n",
     "\n",
     "x = np.linspace(0, 20, 500)\n",
     "\n",
@@ -156,23 +163,10 @@
     "    fig.canvas.flush_events()\n",
     "\n",
     "slider.observe(update_lines, names='value')\n",
+    "fig.canvas.toolbar_visible = False\n",
     "\n",
     "HBox([slider, fig.canvas])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -191,9 +185,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -41,41 +41,9 @@ function get_simple_keys(original) {
     }, {});
 }
 
-/*
- * Return the total size of the margins for an element in both width and height.
- */
-function get_margin_size(el) {
-    var style = getComputedStyle(el);
-
-    var margin_width = parseFloat(style.marginLeft) + parseFloat(style.marginRight);
-    var margin_height = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
-
-    return {
-        width: margin_width,
-        height: margin_height,
-    };
-}
-
-
-/*
- * Return the full size of an element, including margins.
- */
-function get_full_size(el) {
-    var margin_size = get_margin_size(el);
-
-    var full_width = el.scrollWidth + margin_size.width;
-    var full_height = el.scrollHeight + margin_size.height;
-
-    return {
-        width: full_width,
-        height: full_height,
-    };
-}
 
 module.exports = {
   offset: offset,
   get_mouse_position: get_mouse_position,
-  get_simple_keys: get_simple_keys,
-  get_margin_size: get_margin_size,
-  get_full_size: get_full_size,
+  get_simple_keys: get_simple_keys
 }


### PR DESCRIPTION
@kboone if you don't mind looking at it that would be awesome!

I am removing lots of code you added in #147. I am basically removing all resizing logic on the JavaScript side, and matplotlib is entirely responsible for the plot sizing through `figsize` in `plt.figure()` and `fig.set_size_inches()`. Some of this leftover resizing logic was causing some flickering (the front-end was requesting resizes while there was no need for a resize).
I wonder why you added so much logic in the resize

Note that we might put back some of this resizing logic when adding a resize handle on the figure (allowing to resize with the mouse). I am planning to work on this after this cleaning.

I think it is safe to say that it will finally close #117.