### PR TITLE
Move rendering logic in the Widget Model

### DIFF
--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -19,9 +19,175 @@ var MPLCanvasModel = widgets.DOMWidgetModel.extend({
             header_visible: true,
             toolbar: null,
             toolbar_visible: true,
-            toolbar_position: 'horizontal'
+            toolbar_position: 'horizontal',
+            _width: 0,
+            _height: 0,
+            _figure_label: 'Figure',
+            _message: '',
+            _cursor: 'pointer',
+            _image_mode: 'full',
         });
-    }
+    },
+
+    initialize: function(attributes, options) {
+        MPLCanvasModel.__super__.initialize.call(this, attributes, options);
+
+        this.offscreen_canvas = document.createElement('canvas');
+        this.offscreen_context = this.offscreen_canvas.getContext('2d');
+        var backingStore = this.offscreen_context.backingStorePixelRatio ||
+            this.offscreen_context.webkitBackingStorePixelRatio ||
+            this.offscreen_context.mozBackingStorePixelRatio ||
+            this.offscreen_context.msBackingStorePixelRatio ||
+            this.offscreen_context.oBackingStorePixelRatio || 1;
+
+        this.ratio = (window.devicePixelRatio || 1) / backingStore;
+        this._init_image();
+
+        this.on('msg:custom', this.on_comm_message.bind(this));
+
+        this.send_initialization_message();
+    },
+
+    send_message: function(type, message = {}) {
+        message['type'] = type;
+
+        this.send(message);
+    },
+
+    send_initialization_message: function() {
+        if (this.ratio != 1) {
+            this.send_message('set_dpi_ratio', {'dpi_ratio': this.ratio});
+        }
+
+        this.send_message('send_image_mode');
+        this.send_message('refresh');
+
+        this.send_message('initialized');
+    },
+
+    send_draw_message: function() {
+        if (!this.waiting) {
+            this.waiting = true;
+            this.send_message('draw');
+        }
+    },
+
+    handle_save: function() {
+        var save = document.createElement('a');
+        save.href = this.offscreen_canvas.toDataURL();
+        save.download = this.get('_figure_label') + '.png';
+        document.body.appendChild(save);
+        save.click();
+        document.body.removeChild(save);
+    },
+
+    handle_resize: function(msg) {
+        var size = msg['size'];
+        this.resize_canvas(size[0], size[1]);
+        this._for_each_view(function(view) {
+            view.resize_canvas(size[0], size[1]);
+        });
+        this.send_message('refresh');
+    },
+
+    resize_canvas: function(width, height) {
+        this.offscreen_canvas.setAttribute('width', width * this.ratio);
+        this.offscreen_canvas.setAttribute('height', height * this.ratio);
+        this.offscreen_canvas.style.width = width + 'px';
+        this.offscreen_canvas.style.height = height + 'px';
+    },
+
+    handle_rubberband: function(msg) {
+        var x0 = msg['x0'] / this.ratio;
+        var y0 = (this.offscreen_canvas.height - msg['y0']) / this.ratio;
+        var x1 = msg['x1'] / this.ratio;
+        var y1 = (this.offscreen_canvas.height - msg['y1']) / this.ratio;
+        x0 = Math.floor(x0) + 0.5;
+        y0 = Math.floor(y0) + 0.5;
+        x1 = Math.floor(x1) + 0.5;
+        y1 = Math.floor(y1) + 0.5;
+        var min_x = Math.min(x0, x1);
+        var min_y = Math.min(y0, y1);
+        var width = Math.abs(x1 - x0);
+        var height = Math.abs(y1 - y0);
+
+        this._for_each_view(function(view) {
+            view.rubberband_context.clearRect(
+                0, 0, view.rubberband_canvas.width, view.rubberband_canvas.height);
+
+            view.rubberband_context.strokeRect(min_x, min_y, width, height);
+        });
+    },
+
+    handle_draw: function(msg) {
+        // Request the server to send over a new figure.
+        this.send_draw_message();
+    },
+
+    handle_binary: function(msg, dataviews) {
+        var url_creator = window.URL || window.webkitURL;
+
+        var buffer = new Uint8Array(dataviews[0].buffer);
+        var blob = new Blob([buffer], {type: 'image/png'});
+        var image_url = url_creator.createObjectURL(blob);
+
+        // Free the memory for the previous frames
+        if (this.image.src) {
+            url_creator.revokeObjectURL(this.image.src);
+        }
+
+        this.image.src = image_url;
+
+        // Tell Jupyter that the notebook contents must change.
+        this.send_message('ack');
+
+        this.waiting = false;
+    },
+
+    on_comm_message: function(evt, dataviews) {
+        var msg = JSON.parse(evt.data);
+        var msg_type = msg['type'];
+
+        // Call the  'handle_{type}' callback, which takes
+        // the figure and JSON message as its only arguments.
+        try {
+            var callback = this['handle_' + msg_type].bind(this);
+        } catch (e) {
+            console.log('No handler for the \'' + msg_type + '\' message type: ', msg);
+            return;
+        }
+
+        if (callback) {
+            callback(msg, dataviews);
+        }
+    },
+
+    _init_image: function() {
+        var that = this;
+
+        this.image = document.createElement('img');
+        this.image.onload = function() {
+            if (that.get('_image_mode') == 'full') {
+                // Full images could contain transparency (where diff images
+                // almost always do), so we need to clear the canvas so that
+                // there is no ghosting.
+                that.offscreen_context.clearRect(0, 0, that.offscreen_canvas.width, that.offscreen_canvas.height);
+            }
+            that.offscreen_context.drawImage(that.image, 0, 0);
+
+            that._for_each_view(function(view) {
+                view.context.drawImage(that.offscreen_canvas, 0, 0);
+            });
+        };
+    },
+
+    _for_each_view: function(callback) {
+        for (const view_id in this.views) {
+            this.views[view_id].then((view) => {
+                callback(view);
+            });
+        }
+    },
 }, {
     serializers: _.extend({
         toolbar: { deserialize: widgets.unpack_models }
@@ -35,15 +201,12 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
         this.rubberband_canvas = undefined;
         this.rubberband_context = undefined;
 
-        this.image_mode = 'full';
-
         this.figure = document.createElement('div');
         this.figure.addEventListener('remove', this.close.bind(this));
         this.figure.classList = 'jupyter-matplotlib-figure jupyter-widgets widget-container widget-box widget-vbox';
 
         this._init_header();
         this._init_canvas();
-        this._init_image();
         this._init_footer();
 
         this.waiting = false;
@@ -53,43 +216,33 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
         return this.create_child_view(this.model.get('toolbar')).then(function(toolbar_view) {
             that.toolbar_view = toolbar_view;
 
-            that.update_toolbar_position();
+            that._update_toolbar_position();
 
-            that.update_header_visible();
-            that.update_toolbar_visible();
+            that._update_header_visible();
+            that._update_toolbar_visible();
 
             that.model_events();
-
-            that.send_initialization_message();
         });
     },
 
     model_events: function() {
-        this.model.on('msg:custom', this.on_comm_message.bind(this));
-        this.model.on('change:header_visible', this.update_header_visible.bind(this));
-        this.model.on('change:toolbar_visible', this.update_toolbar_visible.bind(this));
-        this.model.on('change:toolbar_position', this.update_toolbar_position.bind(this));
+        this.model.on('change:header_visible', this._update_header_visible.bind(this));
+        this.model.on('change:toolbar_visible', this._update_toolbar_visible.bind(this));
+        this.model.on('change:toolbar_position', this._update_toolbar_position.bind(this));
+        this.model.on('change:_figure_label', this._update_figure_label.bind(this));
+        this.model.on('change:_message', this._update_message.bind(this));
+        this.model.on('change:_cursor', this._update_cursor.bind(this));
     },
 
-    send_initialization_message: function() {
-        if (this.ratio != 1) {
-            this.send_message('set_dpi_ratio', {'dpi_ratio': this.ratio});
-        }
-        this.send_message('send_image_mode');
-        this.send_message('refresh');
-
-        this.send_message('initialized');
-    },
-
-    update_header_visible: function() {
+    _update_header_visible: function() {
         this.header.style.display = this.model.get('header_visible') ? '': 'none';
     },
 
-    update_toolbar_visible: function() {
+    _update_toolbar_visible: function() {
         this.toolbar_view.el.style.display = this.model.get('toolbar_visible') ? '' : 'none';
     },
 
-    update_toolbar_position: function() {
+    _update_toolbar_position: function() {
         var toolbar_position = this.model.get('toolbar_position');
         if (toolbar_position == 'top' || toolbar_position == 'bottom') {
             this.el.classList = 'jupyter-widgets widget-container widget-box widget-vbox jupyter-matplotlib';
@@ -129,10 +282,13 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
     _init_header: function() {
         this.header = document.createElement('div');
         this.header.style.textAlign = 'center';
-        this.header.style.flexGrow = 0;
-        this.header.style.flexShrink = 0;
         this.header.classList = 'jupyter-widgets widget-label';
+        this._update_figure_label();
         this.figure.appendChild(this.header);
+    },
+
+    _update_figure_label: function(msg) {
+        this.header.textContent = this.model.get('_figure_label');
     },
 
     _init_canvas: function() {
@@ -156,15 +312,6 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
         canvas.style.zIndex = 0;
 
         this.context = canvas.getContext('2d');
-
-        var backingStore = this.context.backingStorePixelRatio ||
-            this.context.webkitBackingStorePixelRatio ||
-            this.context.mozBackingStorePixelRatio ||
-            this.context.msBackingStorePixelRatio ||
-            this.context.oBackingStorePixelRatio ||
-            this.context.backingStorePixelRatio || 1;
-
-        this.ratio = (window.devicePixelRatio || 1) / backingStore;
 
         var rubberband_canvas = this.rubberband_canvas = document.createElement('canvas');
         rubberband_canvas.style.display = 'block';
@@ -194,179 +341,39 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
             event.stopPropagation();
             return false;
         });
+
+        this.resize_canvas(this.model.get('_width'), this.model.get('_height'));
+        this.context.drawImage(this.model.offscreen_canvas, 0, 0);
     },
 
-    _init_image: function() {
-        var that = this;
-        this.image = document.createElement('img');
-        this.image.style.display = 'none';
-
-        this.figure.appendChild(this.image);
-        this.image.onload = function() {
-            if (that.image_mode == 'full') {
-                // Full images could contain transparency (where diff images
-                // almost always do), so we need to clear the canvas so that
-                // there is no ghosting.
-                that.context.clearRect(0, 0, that.canvas.width, that.canvas.height);
-            }
-            that.context.drawImage(that.image, 0, 0);
-        };
-
-        this.image.onunload = function() {
-            that.close();
-        }
+    _update_cursor: function() {
+        this.rubberband_canvas.style.cursor = this.model.get('_cursor');
     },
 
     _init_footer: function() {
         this.footer = document.createElement('div');
         this.footer.style.textAlign = 'center';
-        this.header.style.flexGrow = 0;
-        this.header.style.flexShrink = 0;
         this.footer.classList = 'jupyter-widgets widget-label';
+        this._update_message();
         this.figure.appendChild(this.footer);
     },
 
-    _resize_canvas: function(width, height) {
+    _update_message: function() {
+        this.footer.textContent = this.model.get('_message');
+    },
+
+    resize_canvas: function(width, height) {
         // Keep the size of the canvas, and rubber band canvas in sync.
-        this.canvas.setAttribute('width', width * this.ratio);
-        this.canvas.setAttribute('height', height * this.ratio);
+        this.canvas.setAttribute('width', width * this.model.ratio);
+        this.canvas.setAttribute('height', height * this.model.ratio);
         this.canvas.style.width = width + 'px';
+        this.canvas.style.height = height + 'px';
 
         this.rubberband_canvas.setAttribute('width', width);
         this.rubberband_canvas.setAttribute('height', height);
 
         this.canvas_div.style.width = width + 'px';
         this.canvas_div.style.height = height + 'px';
-    },
-
-    send_message: function(type, message = {}) {
-        message['type'] = type;
-
-        this.send(message);
-    },
-
-    send_draw_message: function() {
-        if (!this.waiting) {
-            this.waiting = true;
-            this.send_message('draw');
-        }
-    },
-
-    handle_save: function() {
-        var save = document.createElement('a');
-        save.href = this.canvas.toDataURL();
-        save.download = this.header.textContent + '.png';
-        document.body.appendChild(save);
-        save.click();
-        document.body.removeChild(save);
-    },
-
-    handle_resize: function(msg) {
-        var size = msg['size'];
-        if (size[0] != this.canvas.width || size[1] != this.canvas.height) {
-            this._resize_canvas(size[0], size[1]);
-            this.send_message('refresh');
-        };
-    },
-
-    handle_rubberband: function(msg) {
-        var x0 = msg['x0'] / this.ratio;
-        var y0 = (this.canvas.height - msg['y0']) / this.ratio;
-        var x1 = msg['x1'] / this.ratio;
-        var y1 = (this.canvas.height - msg['y1']) / this.ratio;
-        x0 = Math.floor(x0) + 0.5;
-        y0 = Math.floor(y0) + 0.5;
-        x1 = Math.floor(x1) + 0.5;
-        y1 = Math.floor(y1) + 0.5;
-        var min_x = Math.min(x0, x1);
-        var min_y = Math.min(y0, y1);
-        var width = Math.abs(x1 - x0);
-        var height = Math.abs(y1 - y0);
-
-        this.rubberband_context.clearRect(
-            0, 0, this.canvas.width, this.canvas.height);
-
-        this.rubberband_context.strokeRect(min_x, min_y, width, height);
-    },
-
-    handle_figure_label: function(msg) {
-        // Updates the figure title.
-        this.header.textContent = msg['label'];
-    },
-
-    handle_message: function(msg) {
-        this.footer.textContent = msg['message'];
-    },
-
-    handle_cursor: function(msg) {
-        var cursor = msg['cursor'];
-        switch(cursor)
-        {
-        case 0:
-            cursor = 'pointer';
-            break;
-        case 1:
-            cursor = 'default';
-            break;
-        case 2:
-            cursor = 'crosshair';
-            break;
-        case 3:
-            cursor = 'move';
-            break;
-        }
-        this.rubberband_canvas.style.cursor = cursor;
-    },
-
-    handle_draw: function(msg) {
-        // Request the server to send over a new figure.
-        this.send_draw_message();
-    },
-
-    handle_binary: function(msg, dataviews) {
-        var url_creator = window.URL || window.webkitURL;
-
-        var buffer = new Uint8Array(dataviews[0].buffer);
-        var blob = new Blob([buffer], {type: 'image/png'});
-        var image_url = url_creator.createObjectURL(blob);
-
-        // Free the memory for the previous frames
-        if (this.image.src) {
-            url_creator.revokeObjectURL(this.image.src);
-        }
-
-        this.image.src = image_url;
-
-        // Tell Jupyter that the notebook contents must change.
-        this.send_message('ack');
-
-        this.waiting = false;
-    },
-
-    handle_image_mode: function(msg) {
-        this.image_mode = msg['mode'];
-    },
-
-    on_comm_message: function(evt, dataviews) {
-        var msg = JSON.parse(evt.data);
-        var msg_type = msg['type'];
-
-        // Call the  'handle_{type}' callback, which takes
-        // the figure and JSON message as its only arguments.
-        try {
-            var callback = this['handle_' + msg_type].bind(this);
-        } catch (e) {
-            console.log('No handler for the \'' + msg_type + '\' message type: ', msg);
-            return;
-        }
-
-        if (callback) {
-            try {
-                callback(msg, dataviews);
-            } catch (e) {
-                console.log('Exception inside the \'handler_' + msg_type + '\' callback:', e, e.stack, msg);
-            }
-        }
     },
 
     mouse_event: function(name) {
@@ -394,10 +401,10 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
             if (Date.now() > last_update + 16) {
                 last_update = Date.now();
 
-                var x = canvas_pos.x * that.ratio;
-                var y = canvas_pos.y * that.ratio;
+                var x = canvas_pos.x * that.model.ratio;
+                var y = canvas_pos.y * that.model.ratio;
 
-                that.send_message(name, {x: x, y: y, button: event.button,
+                that.model.send_message(name, {x: x, y: y, button: event.button,
                                         step: event.step,
                                         guiEvent: utils.get_simple_keys(event)});
             }
@@ -439,7 +446,7 @@ var MPLCanvasView = widgets.DOMWidgetView.extend({
             value += 'k';
             value += event.which.toString();
 
-            that.send_message(name, {key: value, guiEvent: utils.get_simple_keys(event)});
+            that.model.send_message(name, {key: value, guiEvent: utils.get_simple_keys(event)});
             return false;
         };
     },


### PR DESCRIPTION
This will fix #175 
This PR will make everything more robust/fast. Only the widget model is responsible for communication with the server, not each view.

It also makes the widget more stateful, by adding the header/footer/cursor as part of the widget state.