### PR TITLE
Clean Notebook example

### DIFF
--- a/examples/ipympl.ipynb
+++ b/examples/ipympl.ipynb
@@ -30,12 +30,11 @@
    "outputs": [],
    "source": [
     "# Testing matplotlib interactions with a simple plot\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
     "fig = plt.figure()\n",
-    "plt.plot(np.sin(np.linspace(0, 20, 100)))"
+    "plt.plot(np.sin(np.linspace(0, 20, 100)));"
    ]
   },
   {
@@ -83,8 +82,6 @@
     "# Plot a basic wireframe.\n",
     "ax.plot_wireframe(X, Y, Z, rstride=10, cstride=10)\n",
     "\n",
-    "fig.canvas.layout.max_width = '800px'\n",
-    "\n",
     "plt.show()"
    ]
   },
@@ -95,10 +92,6 @@
    "outputs": [],
    "source": [
     "# A more complex example from the matplotlib gallery\n",
-    "\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
     "np.random.seed(0)\n",
     "\n",
     "n_bins = 10\n",
@@ -160,7 +153,6 @@
     "from ipywidgets import HBox, FloatSlider\n",
     "\n",
     "plt.ioff()\n",
-    "plt.clf()\n",
     "\n",
     "slider = FloatSlider(\n",
     "    orientation='vertical',\n",


### PR DESCRIPTION
Some Notebook cleaning.

It also removes the `plt.clf()` function call which was making one of the plot blank in the case of Voila. 