### PR TITLE
Disable resize request for very small sizes

### DIFF
--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -110,6 +110,11 @@ var MPLCanvasModel = widgets.DOMWidgetModel.extend({
     },
 
     resize: function(width, height) {
+        // Do not request a super small size, as it seems to break the back-end
+        if (width <= 5 || height <= 5) {
+            return;
+        }
+
         this._for_each_view(function(view) {
             // Do an initial resize of each view, stretching the old canvas.
             view.resize_canvas(width, height);


### PR DESCRIPTION
This was causing the matplotlib renderer to stop rendering.

Before this PR:
![before](https://user-images.githubusercontent.com/21197331/75524569-778d1c80-5a0e-11ea-97fb-605ab2eda93c.gif)

After this PR:
![after](https://user-images.githubusercontent.com/21197331/75524583-7e1b9400-5a0e-11ea-9127-b1aeeecb68f6.gif)
