### PR TITLE
Fix doc build issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ defaults:
     shell: bash -l {0}
 jobs:
   build_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Conda environment with Micromamba

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,11 +64,11 @@ copybutton_prompt_text = r">>> |\.\.\. "  # doctest
 linkcheck_anchors = False
 linkcheck_ignore = []  # type: ignore
 
-execution_timeout = -1
-jupyter_execute_notebooks = "off"
+nb_execution_timeout = -1
+nb_execution_mode = "off"
 if "EXECUTE_NB" in os.environ:
     print("\033[93;1mWill run Jupyter notebooks!\033[0m")
-    jupyter_execute_notebooks = "force"
+    nb_execution_mode = "force"
 
 # Settings for myst-parser
 myst_enable_extensions = [

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,6 +57,7 @@ After a change wait for the build to finish and then refresh your browser and th
 If you make a change to the python code then you will need to restart the notebook kernel to have it take effect.
 
 
+(documentation)=
 ## Documentation
 
 Our documentation is built with [Sphinx](https://www.sphinx-doc.org) from the notebooks in the `docs` folder. It contains both Markdown files and Jupyter notebooks.


### PR DESCRIPTION
Fix doc build issues:

- Update github runner to `ubuntu-24.04` (`ubuntu-20.04` is obsolete)
- Fix myst-nb deprecations
- Fix link to `documentation` heading